### PR TITLE
World coordinates support

### DIFF
--- a/elastix_napari/__init__.py
+++ b/elastix_napari/__init__.py
@@ -3,7 +3,7 @@ from .elastix_registration import napari_experimental_provide_dock_widget
 __author__ = "Viktor van der Valk"
 __email__ = "v.o.van_der_valk@lumc.nl"
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 
 def get_module_version():

--- a/elastix_napari/elastix_registration.py
+++ b/elastix_napari/elastix_registration.py
@@ -88,8 +88,8 @@ def on_init(widget):
                                    'samples to use'})
 def elastix_registration(fixed: 'napari.layers.Image',
                          moving: 'napari.layers.Image', preset: str,
-                         fixed_mask: 'napari.types.ImageData',
-                         moving_mask: 'napari.types.ImageData',
+                         fixed_mask: 'napari.layers.Image',
+                         moving_mask: 'napari.layers.Image',
                          fixed_ps: Sequence[Path], moving_ps: Sequence[Path],
                          param1: Sequence[Path], param2: Sequence[Path],
                          param3: Sequence[Path], init_trans: Sequence[Path],
@@ -177,14 +177,12 @@ def elastix_registration(fixed: 'napari.layers.Image',
             print("No masks selected for registration")
             return utils.error("No masks selected for registration")
         else:
-            # Casting to numpy and itk is currently necessary
-            # because of napari's type ambiguity.
-
             if moving_mask is None:
-                # fixed_mask = np.asarray(fixed_mask).astype(np.uint8)
-                # fixed_mask = itk.image_view_from_array(fixed_mask)
-
+                # Convert mask layer to itk_image
                 fixed_mask = image_from_image_layer(fixed_mask)
+                fixed_mask = fixed_mask.astype(itk.UC)
+
+                # Call elastix
                 result_image, rtp = itk.elastix_registration_method(
                     fixed, moving, parameter_object, fixed_mask=fixed_mask,
                     fixed_point_set_file_name=fixed_ps,
@@ -193,10 +191,11 @@ def elastix_registration(fixed: 'napari.layers.Image',
                     log_to_console=False)
 
             elif fixed_mask is None:
-                # moving_mask = np.asarray(moving_mask).astype(np.uint8)
-                # moving_mask = itk.image_view_from_array(moving_mask)
+                # Convert mask layer to itk_image
                 moving_mask = image_from_image_layer(moving_mask)
+                moving_mask = moving_mask.astype(itk.UC)
 
+                # Call elastix
                 result_image, rtp = itk.elastix_registration_method(
                     fixed, moving, parameter_object, moving_mask=moving_mask,
                     fixed_point_set_file_name=fixed_ps,
@@ -204,14 +203,13 @@ def elastix_registration(fixed: 'napari.layers.Image',
                     initial_transform_parameter_file_name=init_trans,
                     log_to_console=False)
             else:
-                # fixed_mask = np.asarray(fixed_mask).astype(np.uint8)
-                # fixed_mask = itk.image_view_from_array(fixed_mask)
+                # Convert mask layer to itk_image
                 fixed_mask = image_from_image_layer(fixed_mask)
+                fixed_mask = fixed_mask.astype(itk.UC)
                 moving_mask = image_from_image_layer(moving_mask)
+                moving_mask = moving_mask.astype(itk.UC)
 
-                # moving_mask = np.asarray(moving_mask).astype(np.uint8)
-                # moving_mask = itk.image_view_from_array(moving_mask)
-
+                # Call elastix
                 result_image, rtp = itk.elastix_registration_method(
                     fixed, moving, parameter_object, fixed_mask=fixed_mask,
                     moving_mask=moving_mask,

--- a/elastix_napari/elastix_registration.py
+++ b/elastix_napari/elastix_registration.py
@@ -98,7 +98,7 @@ def elastix_registration(fixed: 'napari.layers.Image',
                          nr_spatial_samples: int = 512,
                          max_step_length: float = 1.0,  masks: bool = False,
                          advanced: bool = False
-                         ) -> 'napari.types.LayerDataTuple':
+                         ) -> 'napari.layers.Image':
     """
     Takes user input and calls elastix' registration function in itkelastix.
     """
@@ -127,16 +127,11 @@ def elastix_registration(fixed: 'napari.layers.Image',
         fixed_ps = ''
         moving_ps = ''
 
-    # Casting to numpy is currently necessary
-    # because of napari's type ambiguity.
-    print(type(fixed))
-    print(fixed.metadata)
-    print(fixed.translate)
+    # Convert image layer to itk_image
     fixed = image_from_image_layer(fixed)
     moving = image_from_image_layer(moving)
-    print(type(fixed))
-    # fixed = np.asarray(fixed).astype(np.float32)
-    # moving = np.asarray(moving).astype(np.float32)
+    fixed = fixed.astype(itk.F)
+    moving = moving.astype(itk.F)
 
     parameter_object = itk.ParameterObject.New()
     if preset == "custom":
@@ -225,8 +220,9 @@ def elastix_registration(fixed: 'napari.layers.Image',
                     initial_transform_parameter_file_name=init_trans,
                     log_to_console=False)
 
-    return image_layer_from_image(result_image)
-    # return np.asarray(result_image).astype(np.float32), {'name': preset + ' Registration'}
+    layer = image_layer_from_image(result_image)
+    layer.name = preset + " Registration"
+    return layer
 
 
 @napari_hook_implementation

--- a/elastix_napari/tests/test_registration.py
+++ b/elastix_napari/tests/test_registration.py
@@ -4,6 +4,8 @@ import itk
 from elastix_napari import elastix_registration
 import numpy as np
 from qtpy.QtWidgets import QMessageBox
+from itk_napari_conversion import image_layer_from_image
+from itk_napari_conversion import image_from_image_layer
 
 
 # Test widget function
@@ -33,6 +35,7 @@ def image_generator(x1, x2, y1, y2, mask=False, artefact=False,
     if artefact:
         image[-10:, :] = 1
     image = itk.image_view_from_array(image)
+    image = image_layer_from_image(image)
     return image
 
 
@@ -45,8 +48,8 @@ def get_er(*args, **kwargs):
 def test_registration():
     fixed_image = image_generator(25, 75, 25, 75)
     moving_image = image_generator(1, 51, 10, 60)
-    result_image = get_er(fixed_image, moving_image, preset='rigid')[0]
-    mean_diff = np.absolute(np.subtract(result_image, fixed_image)).mean()
+    result_image = get_er(fixed_image, moving_image, preset='rigid')
+    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.001
 
 
@@ -61,11 +64,11 @@ def test_masked_registration():
 
     result_image = get_er(fixed=fixed_image, moving=moving_image,
                           fixed_mask=fixed_mask, moving_mask=moving_mask,
-                          preset='rigid', masks=True)[0]
+                          preset='rigid', masks=True)
 
     # Filter artifacts out of the images.
-    masked_fixed_image = np.asarray(fixed_image)[0:90, 0:90]
-    masked_result_image = result_image[0:90, 0:90]
+    masked_fixed_image = np.asarray(image_from_image_layer(fixed_image))[0:90, 0:90]
+    masked_result_image = np.asarray(image_from_image_layer(result_image))[0:90, 0:90]
 
     mean_diff = np.absolute(np.subtract(masked_fixed_image,
                                         masked_result_image)).mean()
@@ -85,9 +88,9 @@ def test_pointset_registration(data_dir):
 
     result_image = get_er(fixed_image, moving_image, fixed_ps=fixed_ps,
                           moving_ps=moving_ps, preset='rigid',
-                          advanced=True)[0]
+                          advanced=True)
 
-    mean_diff = np.absolute(np.subtract(result_image, fixed_image)).mean()
+    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.001
 
 
@@ -99,9 +102,9 @@ def test_custom_registration(data_dir):
     filename = "parameters_Rigid.txt"
     result_image = get_er(fixed_image, moving_image, preset='custom',
                           param1=(str(data_dir / filename), 'x'),
-                          param2=(str(data_dir / filename), 'x'))[0]
+                          param2=(str(data_dir / filename), 'x'))
 
-    mean_diff = np.absolute(np.subtract(result_image, fixed_image)).mean()
+    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.01
 
 
@@ -113,8 +116,8 @@ def test_initial_transform(data_dir):
     result_image = get_er(
         fixed_image, moving_image, preset='rigid',
         init_trans=(str(data_dir / init_trans_filename), 'x'), resolutions=6,
-        max_iterations=500, advanced=True)[0]
-    mean_diff = np.absolute(np.subtract(result_image, fixed_image)).mean()
+        max_iterations=500, advanced=True)
+    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.01
 
 

--- a/elastix_napari/tests/test_registration.py
+++ b/elastix_napari/tests/test_registration.py
@@ -49,7 +49,9 @@ def test_registration():
     fixed_image = image_generator(25, 75, 25, 75)
     moving_image = image_generator(1, 51, 10, 60)
     result_image = get_er(fixed_image, moving_image, preset='rigid')
-    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
+    mean_diff = np.absolute(np.subtract(
+        np.asarray(image_from_image_layer(result_image)),
+        np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.001
 
 
@@ -67,8 +69,10 @@ def test_masked_registration():
                           preset='rigid', masks=True)
 
     # Filter artifacts out of the images.
-    masked_fixed_image = np.asarray(image_from_image_layer(fixed_image))[0:90, 0:90]
-    masked_result_image = np.asarray(image_from_image_layer(result_image))[0:90, 0:90]
+    masked_fixed_image = np.asarray(
+        image_from_image_layer(fixed_image))[0:90, 0:90]
+    masked_result_image = np.asarray(
+        image_from_image_layer(result_image))[0:90, 0:90]
 
     mean_diff = np.absolute(np.subtract(masked_fixed_image,
                                         masked_result_image)).mean()
@@ -90,7 +94,9 @@ def test_pointset_registration(data_dir):
                           moving_ps=moving_ps, preset='rigid',
                           advanced=True)
 
-    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
+    mean_diff = np.absolute(np.subtract(
+        np.asarray(image_from_image_layer(result_image)),
+        np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.001
 
 
@@ -104,7 +110,9 @@ def test_custom_registration(data_dir):
                           param1=(str(data_dir / filename), 'x'),
                           param2=(str(data_dir / filename), 'x'))
 
-    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
+    mean_diff = np.absolute(np.subtract(
+        np.asarray(image_from_image_layer(result_image)),
+        np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.01
 
 
@@ -117,7 +125,9 @@ def test_initial_transform(data_dir):
         fixed_image, moving_image, preset='rigid',
         init_trans=(str(data_dir / init_trans_filename), 'x'), resolutions=6,
         max_iterations=500, advanced=True)
-    mean_diff = np.absolute(np.subtract(np.asarray(image_from_image_layer(result_image)), np.asarray(image_from_image_layer(fixed_image)))).mean()
+    mean_diff = np.absolute(np.subtract(
+        np.asarray(image_from_image_layer(result_image)),
+        np.asarray(image_from_image_layer(fixed_image)))).mean()
     assert mean_diff < 0.01
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ numpy>=1.19.0
 napari>=0.4.6
 napari-plugin-engine>=0.1.4
 magicgui>=0.2.6
+itk_napari_conversion>=0.3.1
+napari-itk-io>=0.1.0


### PR DESCRIPTION
I've tried to implement the itk_napari_conversion plugin, but it returns an image layer in this class:

<class 'itk.itkImagePython.itkImageSS2'>

which is cannot be handled by itk_elastix, since it's not wrapped for this format.

I tried to make the plugin return floats, but I did not quite manage jet.

Could you have a look?

You can see the error if you try registration with this branch in napari.