### PR TITLE
DOC: Add missing napari hub documentation components

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,3 +1,5 @@
 project_urls:
     Project Site: https://elastix.lumc.nl/
-    Report Issues: https://github.com/SuperElastix/elastix_napari/issues
+    Bug Tracker: https://github.com/SuperElastix/elastix_napari/issues
+    Source Code: https://github.com/SuperElastix/elastix_napari
+    User Support: https://groups.google.com/g/elastix-imageregistration


### PR DESCRIPTION
Reported by the napari-hub-cli.
