### PR TITLE
Include a GUI backend with the napari requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 itk-elastix>=0.11.1
 numpy>=1.19.0
-napari>=0.4.6
+napari[all]>=0.4.6
 napari-plugin-engine>=0.1.4
 magicgui>=0.2.6
 itk_napari_conversion>=0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 itk-elastix>=0.11.1
 numpy>=1.19.0
-napari[all]>=0.4.6
+"napari[all]">=0.4.6
 napari-plugin-engine>=0.1.4
 magicgui>=0.2.6
 itk_napari_conversion>=0.3.1


### PR DESCRIPTION
I was trying this napari plugin out today, and found that creating a new conda environment, and pip installing elastix_napari leads to a broken environment.

napari is listed as a dependency of this project but no GUI backend is specified, so when you launch napari it doesn't work - there's no backend installed. https://napari.org/tutorials/fundamentals/installation#choosing-a-different-qt-backend

I suggest that you include the backend for napari, with `pip install "napari[all]"`, which gives you the default choice.