### PR TITLE
Bump magicgui requirement to avoid bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ itk-elastix>=0.11.1
 numpy>=1.19.0
 napari>=0.4.6
 napari-plugin-engine>=0.1.4
-magicgui>=0.2.6
+magicgui>=0.2.6,<0.4.0
 itk_napari_conversion>=0.3.1
 napari-itk-io>=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ itk-elastix>=0.11.1
 numpy>=1.19.0
 napari>=0.4.6
 napari-plugin-engine>=0.1.4
-magicgui>=0.2.6,<0.4.0
+magicgui>=0.4.0
 itk_napari_conversion>=0.3.1
 napari-itk-io>=0.1.0


### PR DESCRIPTION
Interim, partial solution for https://github.com/SuperElastix/elastix_napari/issues/19

The `elastix_napari` plugin is incompatible with `magicgui` version 0.4.0. This PR pins the requirement to avoid the latest version. It may help as an interim, stop-gap measure while a full solution is worked on.