### PR TITLE
move project urls to standard location

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,8 +1,3 @@
-project_urls:
-    Project Site: https://elastix.lumc.nl/
-    Bug Tracker: https://github.com/SuperElastix/elastix_napari/issues
-    Source Code: https://github.com/SuperElastix/elastix_napari
-    User Support: https://groups.google.com/g/elastix-imageregistration
 # Add labels from the EDAM Bioimaging ontology
 labels:
   ontology: EDAM-BIOIMAGING:alpha06

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,11 @@ setup(
         'Operating System :: OS Independent',
         'License :: OSI Approved :: Apache Software License',
     ],
+    project_urls={
+        'Project Site': 'https://elastix.lumc.nl/',
+        'Bug Tracker': 'https://github.com/SuperElastix/elastix_napari/issues',
+        'Source Code': 'https://github.com/SuperElastix/elastix_napari',
+        'User Support': 'https://groups.google.com/g/elastix-imageregistration',
+    },
     entry_points={'napari.plugin': 'itk-elastix_napari = elastix_napari'},
 )


### PR DESCRIPTION
Hello, in going through some napari plugins with missing metadata, I found your urls in the wrong place.  This fixes that.  Note that you can use `.napari/config.yaml` if you'd like to _override_ how your page appears on the hub, but you should minimally populate the official sources for  [standard metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) 