### PR TITLE
STYLE: Rename function parameters and remove their magicgui labels

### DIFF
--- a/elastix_napari/tests/test_registration.py
+++ b/elastix_napari/tests/test_registration.py
@@ -60,9 +60,9 @@ def test_masked_registration(images, masks, default_rigid):
 @pytest.mark.uncollect_if(func=uncollect_if)
 def test_pointset_registration(images, pointsets, default_rigid):
     fixed_image, moving_image = images
-    fixed_ps, moving_ps = pointsets
-    result_image = get_er(fixed_image, moving_image, fixed_ps=fixed_ps,
-                          moving_ps=moving_ps, preset='rigid',
+    fixed_point_set, moving_point_set = pointsets
+    result_image = get_er(fixed_image, moving_image, fixed_point_set=fixed_point_set,
+                          moving_point_set=moving_point_set, preset='rigid',
                           advanced=True)
     default_rigid.SetParameter(0, "Registration", "MultiMetricMultiResolutionRegistration")
     default_rigid.SetParameter(0, "Metric", [default_rigid.GetParameter(0, "Metric")[0], 
@@ -70,8 +70,8 @@ def test_pointset_registration(images, pointsets, default_rigid):
     reference_result_image, _ = itk.elastix_registration_method(image_from_image_layer(fixed_image), 
                                                              image_from_image_layer(moving_image),
                                                              parameter_object=default_rigid,
-                                                             fixed_point_set_file_name=str(fixed_ps),
-                                                             moving_point_set_file_name=str(moving_ps))
+                                                             fixed_point_set_file_name=str(fixed_point_set),
+                                                             moving_point_set_file_name=str(moving_point_set))
     assert np.allclose(image_from_image_layer(result_image), reference_result_image, atol=0.5)
 
 
@@ -82,7 +82,7 @@ def test_custom_registration(images, data_dir):
     fixed_image, moving_image = images
     filename = "parameters_Rigid.txt"
     result_image = get_er(fixed_image, moving_image, preset='custom',
-                          param1=data_dir / filename)
+                          parameterfile_1=data_dir / filename)
 
     parameter_object = itk.ParameterObject.New()
     parameter_object.AddParameterFile(str(data_dir / filename))
@@ -98,15 +98,15 @@ def test_custom_registration(images, data_dir):
 def test_initial_transform(images, default_rigid, data_dir):
     fixed_image, moving_image = images
     if len(fixed_image.data.shape) == 2:
-        init_trans_filename = "TransformParameters.0_2D.txt"
+        initial_transform_filename = "TransformParameters.0_2D.txt"
     else:
-        init_trans_filename = "TransformParameters.0_3D.txt"
+        initial_transform_filename = "TransformParameters.0_3D.txt"
 
     resolutions = 3
     max_iterations = 50
     result_image = get_er(
         fixed_image, moving_image, preset='rigid',
-        init_trans=data_dir / init_trans_filename, resolutions=resolutions,
+        initial_transform=data_dir / initial_transform_filename, resolutions=resolutions,
         max_iterations=max_iterations, advanced=True)
         
     # TODO: Advanced should take default values from the current parameter map
@@ -119,7 +119,7 @@ def test_initial_transform(images, default_rigid, data_dir):
     reference_result_image, _ = itk.elastix_registration_method(image_from_image_layer(fixed_image), 
                                                              image_from_image_layer(moving_image), 
                                                              parameter_object=default_rigid,
-                                                             initial_transform_parameter_file_name=str(data_dir / init_trans_filename))
+                                                             initial_transform_parameter_file_name=str(data_dir / initial_transform_filename))
     
     diff = image_from_image_layer(result_image)[:] - reference_result_image[:]
     print(diff.min(), diff.max())
@@ -137,7 +137,7 @@ def test_empty_masks(images):
                 preset='rigid', masks=True)
     assert isinstance(im, QMessageBox)
 
-def test_empty_output_dir(images):
+def test_empty_output_directory(images):
     fixed_image, moving_image = images
     im = get_er(fixed_image, moving_image, preset='rigid', save_output=True)
     assert isinstance(im, QMessageBox)
@@ -146,6 +146,6 @@ def test_writing_result(images, tmpdir):
     fixed_image, moving_image = images
     tmpdir = Path(tmpdir)
     im = get_er(fixed_image, moving_image, preset='rigid', save_output=True,
-                output_dir=tmpdir)
+                output_directory=tmpdir)
     assert (tmpdir / "TransformParameters.0.txt").exists()
     


### PR DESCRIPTION
magicgui automatically creates labels based on the parameter names (by default), according to the comment in the code example at https://pyapp-kit.github.io/magicgui/generated_examples/demo_widgets/change_label/

    # use a different label than the default (the parameter name) in the UI
    @magicgui(x={"label": "widget to set x"})
    def example(x=1, y="hi"):