### PR TITLE
BUG: Fix `utils.error(message)` EmitLoopError and AttributeError

### DIFF
--- a/elastix_napari/tests/test_registration.py
+++ b/elastix_napari/tests/test_registration.py
@@ -3,7 +3,6 @@ import elastix_napari
 import itk
 from elastix_napari import elastix_registration
 import numpy as np
-from qtpy.QtWidgets import QMessageBox
 from itk_napari_conversion import image_layer_from_image
 from itk_napari_conversion import image_from_image_layer
 from pathlib import Path
@@ -164,30 +163,6 @@ def test_initial_transform(images, default_rigid, data_dir):
     diff = image_from_image_layer(result_image)[:] - reference_result_image[:]
     print(diff.min(), diff.max())
     assert np.allclose(image_from_image_layer(result_image), reference_result_image)
-
-
-def test_empty_images():
-    im = get_er(None, None, preset="rigid")
-    assert isinstance(im, QMessageBox)
-
-
-def test_empty_masks(images):
-    fixed_image, moving_image = images
-    im = get_er(
-        fixed_image,
-        moving_image,
-        fixed_mask=None,
-        moving_mask=None,
-        preset="rigid",
-        use_masks=True,
-    )
-    assert isinstance(im, QMessageBox)
-
-
-def test_empty_output_directory(images):
-    fixed_image, moving_image = images
-    im = get_er(fixed_image, moving_image, preset="rigid", save_output_to_disk=True)
-    assert isinstance(im, QMessageBox)
 
 
 def test_writing_result(images, tmpdir):

--- a/elastix_napari/tests/test_transformix.py
+++ b/elastix_napari/tests/test_transformix.py
@@ -3,7 +3,6 @@ import itk
 import numpy as np
 from elastix_napari import transformix_widget
 from itk_napari_conversion import image_from_image_layer
-from qtpy.QtWidgets import QMessageBox
 from pathlib import Path
 
 
@@ -24,17 +23,3 @@ def test_transformation(images, default_rigid, tmpdir):
     result_image_trx = np.asarray(image_from_image_layer(result_image_trx))
 
     assert np.allclose(result_image_elx, result_image_trx)
-
-
-def test_empty_image(data_dir):
-    result = transformix_widget.create_transformix_widget()(
-        image=None, transform_file=data_dir / "TransformParameters.0.txt"
-    )
-    assert isinstance(result, QMessageBox)
-
-
-def test_empty_transform_file(images):
-    result = transformix_widget.create_transformix_widget()(
-        image=image_from_image_layer(images[1]), transform_file=Path()
-    )
-    assert isinstance(result, QMessageBox)

--- a/elastix_napari/utils.py
+++ b/elastix_napari/utils.py
@@ -5,13 +5,8 @@ def error(message):
     """
     Shows a pop up with the given error message.
     """
-    e = QMessageBox()
     print("ERROR: ", message)
-    e.setText(message)
-    e.setIcon(QMessageBox.Critical)
-    e.setWindowTitle("Error")
-    e.show()
-    return e
+    QMessageBox.critical(None, "Error", message)
 
 
 def check_filename(filename):


### PR DESCRIPTION
The original code triggered an error, saying:

> EmitLoopError:
>
> While emitting signal 'magicgui.widgets.PushButton.changed', an error occurred in a callback:
>
>  AttributeError: 'QMessageBox' object has no attribute 'source'

----
For the record, here is the complete output:

```
AttributeError                            Traceback (most recent call last)
File src\psygnal\_signal.py:1311, in _run_emit_loop()

File src\psygnal\_signal.py:1340, in _run_emit_loop_immediate()

File src\psygnal\_weak_callback.py:412, in cb()

File ~\.conda\envs\<environment>\Lib\site-packages\magicgui\widgets\_function_gui.py:235, in FunctionGui.__init__.<locals>._disable_button_and_call()
    234 try:
--> 235     self.__call__()  # type: ignore [call-arg]
        self = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>    236 finally:

File ~\.conda\envs\<environment>\Lib\site-packages\magicgui\widgets\_function_gui.py:361, in FunctionGui.__call__(self=<FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>, *args=(), **kwargs={})
    360     for callback in self._type_map.type2callback(return_type):
--> 361         callback(self, value, return_type)
        return_type = <class 'napari.layers.image.image.Image'>
        value = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        self = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>
        callback = <function add_layer_to_viewer at 0x0000021855BCCEA0>    362 self.called.emit(value)

File ~\.conda\envs\<environment>\Lib\site-packages\napari\utils\_magicgui.py:525, in add_layer_to_viewer(gui=<FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>, result=<PyQt5.QtWidgets.QMessageBox object>, return_type=<class 'napari.layers.image.image.Image'>)
    504 """Show a magicgui result in the viewer.
    505
    506 Parameters
   (...)    523
    524 """
--> 525 add_layers_to_viewer(gui, [result], list[return_type])
        gui = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>
        [result] = [<PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>]
        result = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        return_type = <class 'napari.layers.image.image.Image'>
File ~\.conda\envs\<environment>\Lib\site-packages\napari\utils\_magicgui.py:562, in add_layers_to_viewer(gui=<FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>, result=[<PyQt5.QtWidgets.QMessageBox object>], return_type=list[napari.layers.image.image.Image])
    561 if item is not None:
--> 562     _add_layer_to_viewer(item, viewer=viewer, source={'widget': gui})
        viewer = Viewer(camera=Camera(center=(0.0, 0.0, 0.0), zoom=1.0, angles=(0.0, 0.0, 90.0), perspective=0.0, mouse_pan=True, mouse_zoom=True, orientation=(<DepthAxisOrientation.TOWARDS: 'towards'>, <VerticalAxisOrientation.DOWN: 'down'>, <HorizontalAxisOrientation.RIGHT: 'right'>)), cursor=Cursor(position=(1.0, 1.0), viewbox=None, scaled=True, style=<CursorStyle.STANDARD: 'standard'>, size=1.0), dims=Dims(ndim=2, ndisplay=2, order=(0, 1), axis_labels=('0', '1'), rollable=(True, True), range=(RangeTuple(start=0.0, stop=2.0, step=1.0), RangeTuple(start=0.0, stop=2.0, step=1.0)), margin_left=(0.0, 0.0), margin_right=(0.0, 0.0), point=(np.float64(0.0), np.float64(0.0)), last_used=0), grid=GridCanvas(stride=1, shape=(-1, -1), enabled=False, spacing=0.0), layers=[], help='', status='', tooltip=Tooltip(visible=False, text=''), theme='dark', title='napari', mouse_over_canvas=False, mouse_move_callbacks=[], mouse_drag_callbacks=[<function drag_to_zoom at 0x0000021859341300>], mouse_double_click_callbacks=[<function double_click_to_zoom at 0x0000021859341260>], mouse_wheel_callbacks=[<function dims_scroll at 0x00000218593411C0>], _persisted_mouse_event={}, _mouse_drag_gen={}, _mouse_wheel_gen={}, _keymap={})
        item = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        gui = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>
        {'widget': gui} = {'widget': <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>}
File ~\.conda\envs\<environment>\Lib\site-packages\napari\_qt\_qapp_model\injection\_qprocessors.py:133, in _add_layer_to_viewer(layer=<PyQt5.QtWidgets.QMessageBox object>, viewer=Viewer(camera=Camera(center=(0.0, 0.0, 0.0), zoo...use_drag_gen={}, _mouse_wheel_gen={}, _keymap={}), source={'widget': <FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>})
    132 if layer is not None and (viewer := viewer or _provide_viewer()):
--> 133     layer._source = layer.source.copy(update=source or {})
        layer = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        source or {} = {'widget': <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>}
        source = {'widget': <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>}    134     viewer.add_layer(layer)

AttributeError: 'QMessageBox' object has no attribute 'source'

The above exception was the direct cause of the following exception:

EmitLoopError                             Traceback (most recent call last)
File ~\.conda\envs\<environment>\Lib\site-packages\magicgui\widgets\bases\_value_widget.py:69, in BaseValueWidget._on_value_change(self=PushButton(value=False, annotation=None, name='call_button'), value=False)
     67 if value is self.null_value and not self._nullable:
     68     return
---> 69 self.changed.emit(value)
        value = False
        self.changed = <SignalInstance 'changed' on PushButton(value=False, annotation=None, name='call_button')>
        self = PushButton(value=False, annotation=None, name='call_button')
File src\psygnal\_signal.py:1233, in emit()

File src\psygnal\_signal.py:1328, in _run_emit_loop()

File src\psygnal\_signal.py:1311, in _run_emit_loop()

File src\psygnal\_signal.py:1340, in _run_emit_loop_immediate()

File src\psygnal\_weak_callback.py:412, in cb()

File ~\.conda\envs\<environment>\Lib\site-packages\magicgui\widgets\_function_gui.py:235, in FunctionGui.__init__.<locals>._disable_button_and_call()
    233 self._call_button.enabled = False
    234 try:
--> 235     self.__call__()  # type: ignore [call-arg]
        self = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>    236 finally:
    237     self._call_button.enabled = True

File ~\.conda\envs\<environment>\Lib\site-packages\magicgui\widgets\_function_gui.py:361, in FunctionGui.__call__(self=<FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>, *args=(), **kwargs={})
    359 if return_type:
    360     for callback in self._type_map.type2callback(return_type):
--> 361         callback(self, value, return_type)
        return_type = <class 'napari.layers.image.image.Image'>
        value = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        self = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>
        callback = <function add_layer_to_viewer at 0x0000021855BCCEA0>    362 self.called.emit(value)
    363 return value

File ~\.conda\envs\<environment>\Lib\site-packages\napari\utils\_magicgui.py:525, in add_layer_to_viewer(gui=<FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>, result=<PyQt5.QtWidgets.QMessageBox object>, return_type=<class 'napari.layers.image.image.Image'>)
    503 def add_layer_to_viewer(gui, result: Any, return_type: type[Layer]) -> None:
    504     """Show a magicgui result in the viewer.
    505
    506     Parameters
   (...)    523
    524     """
--> 525     add_layers_to_viewer(gui, [result], list[return_type])
        gui = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>
        [result] = [<PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>]
        result = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        return_type = <class 'napari.layers.image.image.Image'>
File ~\.conda\envs\<environment>\Lib\site-packages\napari\utils\_magicgui.py:562, in add_layers_to_viewer(gui=<FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>, result=[<PyQt5.QtWidgets.QMessageBox object>], return_type=list[napari.layers.image.image.Image])
    560 for item in result:
    561     if item is not None:
--> 562         _add_layer_to_viewer(item, viewer=viewer, source={'widget': gui})
        viewer = Viewer(camera=Camera(center=(0.0, 0.0, 0.0), zoom=1.0, angles=(0.0, 0.0, 90.0), perspective=0.0, mouse_pan=True, mouse_zoom=True, orientation=(<DepthAxisOrientation.TOWARDS: 'towards'>, <VerticalAxisOrientation.DOWN: 'down'>, <HorizontalAxisOrientation.RIGHT: 'right'>)), cursor=Cursor(position=(1.0, 1.0), viewbox=None, scaled=True, style=<CursorStyle.STANDARD: 'standard'>, size=1.0), dims=Dims(ndim=2, ndisplay=2, order=(0, 1), axis_labels=('0', '1'), rollable=(True, True), range=(RangeTuple(start=0.0, stop=2.0, step=1.0), RangeTuple(start=0.0, stop=2.0, step=1.0)), margin_left=(0.0, 0.0), margin_right=(0.0, 0.0), point=(np.float64(0.0), np.float64(0.0)), last_used=0), grid=GridCanvas(stride=1, shape=(-1, -1), enabled=False, spacing=0.0), layers=[], help='', status='', tooltip=Tooltip(visible=False, text=''), theme='dark', title='napari', mouse_over_canvas=False, mouse_move_callbacks=[], mouse_drag_callbacks=[<function drag_to_zoom at 0x0000021859341300>], mouse_double_click_callbacks=[<function double_click_to_zoom at 0x0000021859341260>], mouse_wheel_callbacks=[<function dims_scroll at 0x00000218593411C0>], _persisted_mouse_event={}, _mouse_drag_gen={}, _mouse_wheel_gen={}, _keymap={})
        item = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        gui = <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>
        {'widget': gui} = {'widget': <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>}
File ~\.conda\envs\<environment>\Lib\site-packages\napari\_qt\_qapp_model\injection\_qprocessors.py:133, in _add_layer_to_viewer(layer=<PyQt5.QtWidgets.QMessageBox object>, viewer=Viewer(camera=Camera(center=(0.0, 0.0, 0.0), zoo...use_drag_gen={}, _mouse_wheel_gen={}, _keymap={}), source={'widget': <FunctionGui elastix_registration(fixed_image: n...bool = False) -> napari.layers.image.image.Image>})
    127 def _add_layer_to_viewer(
    128     layer: layers.Layer,
    129     viewer: viewer.Viewer | None = None,
    130     source: dict | None = None,
    131 ) -> None:
    132     if layer is not None and (viewer := viewer or _provide_viewer()):
--> 133         layer._source = layer.source.copy(update=source or {})
        layer = <PyQt5.QtWidgets.QMessageBox object at 0x000002186C59BAD0>
        source or {} = {'widget': <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>}
        source = {'widget': <FunctionGui elastix_registration(fixed_image: napari.layers.image.image.Image = None, moving_image: napari.layers.image.image.Image = None, preset: str = 'rigid', fixed_mask: napari.layers.image.image.Image = None, moving_mask: napari.layers.image.image.Image = None, fixed_ps: pathlib._local.Path = WindowsPath('.'), moving_ps: pathlib._local.Path = WindowsPath('.'), param1: pathlib._local.Path = WindowsPath('.'), param2: pathlib._local.Path = WindowsPath('.'), param3: pathlib._local.Path = WindowsPath('.'), init_trans: pathlib._local.Path = WindowsPath('.'), output_dir: pathlib._local.Path = WindowsPath('.'), metric: str = 'AdvancedMattesMutualInformation', resolutions: int = 4, max_iterations: int = 500, nr_spatial_samples: int = 512, max_step_length: float = 1.0, masks: bool = False, save_output: bool = False, advanced: bool = False) -> napari.layers.image.image.Image>}    134         viewer.add_layer(layer)

EmitLoopError:

While emitting signal 'magicgui.widgets.PushButton.changed', an error occurred in a callback:

  AttributeError: 'QMessageBox' object has no attribute 'source'
  --------------------------------------------------------------

  SIGNAL EMISSION:
    C:\Users\<user>\.conda\envs\<environment>\Lib\site-packages\napari\_qt\qt_event_loop.py:413 in run
      app.exec_()
    C:\Users\<user>\.conda\envs\<environment>\Lib\site-packages\magicgui\widgets\bases\_value_widget.py:69 in _on_value_change
      self.changed.emit(value)  # <-- SIGNAL WAS EMITTED HERE

  CALLBACK CHAIN:
    src\psygnal\_signal.py:1311 in _run_emit_loop
    ... 6 more frames ...
    C:\Users\<user>\.conda\envs\<environment>\Lib\site-packages\napari\_qt\_qapp_model\injection\_qprocessors.py:133 in _add_layer_to_viewer
      layer._source = layer.source.copy(update=source or {})  # <-- ERROR OCCURRED HERE

```
