### PR TITLE
Remove `utils.py`, use `napari.utils.notifications.show_error`

### DIFF
--- a/elastix_napari/elastix_registration.py
+++ b/elastix_napari/elastix_registration.py
@@ -180,11 +180,6 @@ def elastix_registration(
     if fixed_point_set.exists() != moving_point_set.exists():
         return utils.error("Select both fixed and moving point set.")
 
-    if not utils.check_filename(fixed_point_set):
-        fixed_point_set = ""
-    if not utils.check_filename(moving_point_set):
-        moving_point_set = ""
-
     # Convert image layer to itk_image
     fixed_image = image_from_image_layer(fixed_image)
     moving_image = image_from_image_layer(moving_image)
@@ -212,7 +207,7 @@ def elastix_registration(
             parameter_map = parameter_object.GetDefaultParameterMap(preset, 4)
 
         if use_corresponding_points:
-            if str(fixed_point_set) == "" or str(moving_point_set) == "":
+            if fixed_point_set == Path() or moving_point_set == Path():
                 return utils.error("Please specify both point sets!")
 
             parameter_map["Registration"] = ["MultiMetricMultiResolutionRegistration"]

--- a/elastix_napari/tests/test_registration.py
+++ b/elastix_napari/tests/test_registration.py
@@ -165,6 +165,28 @@ def test_initial_transform(images, default_rigid, data_dir):
     assert np.allclose(image_from_image_layer(result_image), reference_result_image)
 
 
+def test_empty_images():
+    im = get_er(None, None, preset="rigid")
+    assert im is None
+
+
+def test_empty_masks(images):
+    fixed_image, moving_image = images
+    im = get_er(
+        fixed_image,
+        moving_image,
+        fixed_mask=None,
+        moving_mask=None,
+        preset="rigid",
+        use_masks=True,
+    )
+    assert im is None
+
+def test_empty_output_directory(images):
+    fixed_image, moving_image = images
+    im = get_er(fixed_image, moving_image, preset="rigid", save_output_to_disk=True)
+    assert im is None
+
 def test_writing_result(images, tmpdir):
     fixed_image, moving_image = images
     tmpdir = Path(tmpdir)

--- a/elastix_napari/tests/test_transformix.py
+++ b/elastix_napari/tests/test_transformix.py
@@ -23,3 +23,17 @@ def test_transformation(images, default_rigid, tmpdir):
     result_image_trx = np.asarray(image_from_image_layer(result_image_trx))
 
     assert np.allclose(result_image_elx, result_image_trx)
+
+
+def test_empty_image(data_dir):
+    result = transformix_widget.create_transformix_widget()(
+        image=None, transform_file=data_dir / "TransformParameters.0.txt"
+    )
+    assert result is None
+
+
+def test_empty_transform_file(images):
+    result = transformix_widget.create_transformix_widget()(
+        image=image_from_image_layer(images[1]), transform_file=Path()
+    )
+    assert result is None

--- a/elastix_napari/transformix_widget.py
+++ b/elastix_napari/transformix_widget.py
@@ -1,5 +1,4 @@
 from typing import TYPE_CHECKING
-import elastix_napari.utils as utils
 from magicgui import magic_factory
 import itk
 from itk_napari_conversion import image_from_image_layer, image_layer_from_image
@@ -10,6 +9,7 @@ from pathlib import Path
 if TYPE_CHECKING:
     import napari
 
+from napari.utils import notifications
 
 def on_init(widget):
     """
@@ -45,10 +45,12 @@ def create_transformix_widget(
 ) -> "napari.layers.Image":
 
     if not image:
-        return utils.error("No image selected for transformation")
+        notifications.show_error("No image selected for transformation")
+        return None
 
     if transform_file == Path():
-        return utils.error("Select transformation parameter file")
+        notifications.show_error("Select transformation parameter file")
+        return None
 
     # Convert image layer to itk image
     image = image_from_image_layer(image)

--- a/elastix_napari/utils.py
+++ b/elastix_napari/utils.py
@@ -1,9 +1,0 @@
-from qtpy.QtWidgets import QMessageBox
-
-
-def error(message):
-    """
-    Shows a pop up with the given error message.
-    """
-    print("ERROR: ", message)
-    QMessageBox.critical(None, "Error", message)

--- a/elastix_napari/utils.py
+++ b/elastix_napari/utils.py
@@ -7,13 +7,3 @@ def error(message):
     """
     print("ERROR: ", message)
     QMessageBox.critical(None, "Error", message)
-
-
-def check_filename(filename):
-    """
-    Checks if filename adheres to the correct format.
-    """
-    if (filename.suffix == ".txt") or (filename.suffix == ".vtk"):
-        return True
-    else:
-        return False


### PR DESCRIPTION
`utils.check_filename` was only used to check if the user has specified point set files. Currently, the plugin only supports elastix/transformix specific text files (*.txt).

Replaced our `utils.error`.  The `show_error` function from `napari.utils.notifications` appears preferable, based on discussion at "How to let a napari plugin show an error message?" https://forum.image.sc/t/how-to-let-a-napari-plugin-show-an-error-message/117738, from November 20, 2025.

Removed "utils.py"